### PR TITLE
Save properties on write

### DIFF
--- a/multicompany_property/models/abstract.py
+++ b/multicompany_property/models/abstract.py
@@ -47,3 +47,7 @@ class MulticomanyPropertyAbstract(models.AbstractModel):
             else:
                 return value
         return False
+
+    @api.multi
+    def get_property_fields_list(self):
+        return []

--- a/multicompany_property/models/res_partner.py
+++ b/multicompany_property/models/res_partner.py
@@ -60,3 +60,15 @@ class ResPartnerProperty(models.TransientModel):
         ''' This method must be redefined by modules that
         introduce property fields in the res.partner model '''
         return
+
+    @api.multi
+    def write(self, vals):
+        prop_obj = self.env['ir.property'].with_context(
+            force_company=self.company_id.id)
+        fields = self.get_property_fields_list()
+        for field in fields:
+            if field in vals:
+                for rec in self:
+                    self.set_property(rec.partner_id, field,
+                                      vals[field], prop_obj)
+        return super(ResPartnerProperty, self).write(vals)

--- a/multicompany_property_account/models/product.py
+++ b/multicompany_property_account/models/product.py
@@ -42,6 +42,13 @@ class ProductProperty(models.TransientModel):
             self.get_property_value('property_account_expense_id', object,
                                     properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ProductProperty, self).get_property_fields_list()
+        res.append('property_account_income_id')
+        res.append('property_account_expense_id')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ProductProperty, self).set_properties(object, properties)

--- a/multicompany_property_account/models/product_category.py
+++ b/multicompany_property_account/models/product_category.py
@@ -37,6 +37,13 @@ class ProductCategoryProperty(models.TransientModel):
         self.property_account_expense_categ_id = self.get_property_value(
             'property_account_expense_categ_id', object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ProductCategoryProperty, self).get_property_fields_list()
+        res.append('property_account_income_categ_id')
+        res.append('property_account_expense_categ_id')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ProductCategoryProperty, self).set_properties(object, properties)

--- a/multicompany_property_account/models/res_partner.py
+++ b/multicompany_property_account/models/res_partner.py
@@ -82,17 +82,11 @@ class ResPartnerProperty(models.TransientModel):
                                     object, properties)
 
     @api.multi
-    def write(self, vals):
-        prop_obj = self.env['ir.property'].with_context(
-            force_company=self.company_id.id)
-        fields = ['property_account_payable_id',
-                  'property_account_receivable_id',
-                  'property_account_position_id',
-                  'property_payment_term_id',
-                  'property_supplier_payment_term_id']
-        for field in fields:
-            if field in vals:
-                for rec in self:
-                    self.set_property(rec.partner_id, field,
-                                      vals[field], prop_obj)
-        return super(ResPartnerProperty, self).write(vals)
+    def get_property_fields_list(self):
+        res = super(ResPartnerProperty, self).get_property_fields_list()
+        res.append('property_account_payable_id')
+        res.append('property_account_receivable_id')
+        res.append('property_account_position_id')
+        res.append('property_payment_term_id')
+        res.append('property_supplier_payment_term_id')
+        return res

--- a/multicompany_property_account_asset/models/product.py
+++ b/multicompany_property_account_asset/models/product.py
@@ -34,6 +34,13 @@ class ProductProperty(models.TransientModel):
             self.get_property_value('deferred_revenue_category_id', object,
                                     properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ProductProperty, self).get_property_fields_list()
+        res.append('asset_category_id')
+        res.append('deferred_revenue_category_id')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ProductProperty, self).set_properties(object, properties)

--- a/multicompany_property_delivery/models/res_partner.py
+++ b/multicompany_property_delivery/models/res_partner.py
@@ -24,6 +24,12 @@ class ResPartnerProperty(models.TransientModel):
         self.property_delivery_carrier_id = self.get_property_value(
             'property_delivery_carrier_id', object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ResPartnerProperty, self).get_property_fields_list()
+        res.append('property_delivery_carrier_id')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ResPartnerProperty, self).set_properties(object, properties)

--- a/multicompany_property_product/models/product.py
+++ b/multicompany_property_product/models/product.py
@@ -112,6 +112,8 @@ class MulticompanyPropertyProduct(models.TransientModel):
 
     @api.multi
     def write(self, vals):
+        ''' Standard price do not follow the usual workflow
+        as it has special considerations '''
         prop_obj = self.env['ir.property'].with_context(
             force_company=self.company_id.id)
         if 'standard_price' in vals:
@@ -128,5 +130,11 @@ class MulticompanyPropertyProduct(models.TransientModel):
                     self.set_property(obj, 'standard_price',
                                       vals['standard_price'], prop_obj)
                     obj._set_standard_price(vals.get('standard_price', 0.0))
-
+        fields = self.get_property_fields_list()
+        for field in fields:
+            if field in vals:
+                for rec in self:
+                    obj = rec.product_id or rec.product_template_id
+                    self.set_property(obj, field,
+                                      vals[field], prop_obj)
         return super(MulticompanyPropertyProduct, self).write(vals)

--- a/multicompany_property_product/models/product_category.py
+++ b/multicompany_property_product/models/product_category.py
@@ -57,3 +57,15 @@ class ProductCategoryProperty(models.TransientModel):
     @api.model
     def set_properties(self, object, properties=False):
         return
+
+    @api.multi
+    def write(self, vals):
+        prop_obj = self.env['ir.property'].with_context(
+            force_company=self.company_id.id)
+        fields = self.get_property_fields_list()
+        for field in fields:
+            if field in vals:
+                for rec in self:
+                    self.set_property(rec.partner_id, field,
+                                      vals[field], prop_obj)
+        return super(ProductCategoryProperty, self).write(vals)

--- a/multicompany_property_purchase/models/product.py
+++ b/multicompany_property_purchase/models/product.py
@@ -27,6 +27,12 @@ class ProductProperty(models.TransientModel):
                 'property_account_creditor_price_difference',
                 object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ProductProperty, self).get_property_fields_list()
+        res.append('property_account_creditor_price_difference')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ProductProperty, self).set_properties(object, properties)

--- a/multicompany_property_purchase/models/product_category.py
+++ b/multicompany_property_purchase/models/product_category.py
@@ -28,6 +28,12 @@ class ProductCategoryProperty(models.TransientModel):
                 'property_account_creditor_price_difference_categ',
                 object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ProductCategoryProperty, self).get_property_fields_list()
+        res.append('property_account_creditor_price_difference_categ')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ProductCategoryProperty, self).set_properties(object, properties)

--- a/multicompany_property_purchase/models/res_partner.py
+++ b/multicompany_property_purchase/models/res_partner.py
@@ -26,6 +26,12 @@ class ResPartnerProperties(models.TransientModel):
             self.get_property_value('property_purchase_currency_id',
                                     object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ResPartnerProperties, self).get_property_fields_list()
+        res.append('property_purchase_currency_id')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ResPartnerProperties, self).set_properties()

--- a/multicompany_property_sale_timesheet/models/product.py
+++ b/multicompany_property_sale_timesheet/models/product.py
@@ -29,6 +29,12 @@ class ProductProperty(models.TransientModel):
         self.project_id = self.get_property_value('project_id',
                                                   object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ProductProperty, self).get_property_fields_list()
+        res.append('project_id')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ProductProperty, self).set_properties(object, properties)

--- a/multicompany_property_stock/models/product.py
+++ b/multicompany_property_stock/models/product.py
@@ -44,6 +44,14 @@ class ProductProperty(models.TransientModel):
         self.property_stock_inventory = self.get_property_value(
             'property_stock_inventory', object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ProductProperty, self).get_property_fields_list()
+        res.append('property_stock_procurement')
+        res.append('property_stock_production')
+        res.append('property_stock_inventory')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ProductProperty, self).set_properties(object, properties)

--- a/multicompany_property_stock/models/res_partner.py
+++ b/multicompany_property_stock/models/res_partner.py
@@ -35,6 +35,13 @@ class ResPartnerProperty(models.TransientModel):
         self.property_stock_supplier = self.get_property_value(
             'property_stock_supplier', object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ResPartnerProperty, self).get_property_fields_list()
+        res.append('property_stock_customer')
+        res.append('property_stock_supplier')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ResPartnerProperty, self).set_properties(object, properties)

--- a/multicompany_property_stock_account/models/product.py
+++ b/multicompany_property_stock_account/models/product.py
@@ -77,6 +77,15 @@ class ProductProperty(models.TransientModel):
         self.property_stock_account_output = self.get_property_value(
             'property_stock_account_output', object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ProductProperty, self).get_property_fields_list()
+        res.append('property_valuation')
+        res.append('property_cost_method')
+        res.append('property_stock_account_input')
+        res.append('property_stock_account_output')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ProductProperty, self).set_properties(object, properties)

--- a/multicompany_property_stock_account/models/product_category.py
+++ b/multicompany_property_stock_account/models/product_category.py
@@ -97,6 +97,17 @@ class ProductCategoryProperty(models.TransientModel):
         self.property_stock_valuation_account_id = self.get_property_value(
             'property_stock_valuation_account_id', object, properties)
 
+    @api.multi
+    def get_property_fields_list(self):
+        res = super(ProductCategoryProperty, self).get_property_fields_list()
+        res.append('property_valuation')
+        res.append('property_cost_method')
+        res.append('property_stock_journal')
+        res.append('property_stock_account_input_categ_id')
+        res.append('property_stock_account_output_categ_id')
+        res.append('property_stock_valuation_account_id')
+        return res
+
     @api.model
     def set_properties(self, object, properties=False):
         super(ProductCategoryProperty, self).set_properties(object, properties)


### PR DESCRIPTION
On save, not all properties are saved, because set_properties function is not used. In order to simplify the process and validation, a new function is created: get_property_fields_list, that will allow to check wich fields use the common way and are setted on the write function automatically.