### PR TITLE
[10.0 FIX] Account Move Circular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/_build/
 # Backup files
 *~
 *.swp
+
+# Eclipse
+.settings

--- a/mcfix_account/models/account_move.py
+++ b/mcfix_account/models/account_move.py
@@ -23,7 +23,8 @@ class AccountMove(models.Model):
 
     @api.onchange('company_id')
     def onchange_company_id(self):
-        self.journal_id = False
+        if self.journal_id.company_id != self.company_id:
+            self.journal_id = False
         self.statement_line_id = False
         self.dummy_account_id = False
 


### PR DESCRIPTION
Not possible to create a brand new journal entry manually.

Creating a new account journal entry, choose a journal it sets the
company id, which triggers the onchange to clear the journal entry..