### PR TITLE
[10.0 ENH] Purchase line extras

### DIFF
--- a/mcfix_purchase/models/purchase.py
+++ b/mcfix_purchase/models/purchase.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import api, models, _
+from odoo import api, models, fields, _
 from odoo.exceptions import ValidationError
 
 
@@ -136,6 +136,15 @@ class PurchaseOrder(models.Model):
 
 class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
+
+    company_id = fields.Many2one('res.company', related=[], compute='_compute_line_company', string='Company', store=True, readonly=True)
+
+    @api.depends('order_id', 'order_id.company_id')
+    def _compute_line_company(self):
+        for line in self:
+            line.company_id = line.order_id.company_id
+            if not line.order_id and 'default_company_id' in self.env.context:
+                line.company_id = self.env.context['default_company_id']
 
     @api.multi
     @api.depends('company_id')

--- a/mcfix_purchase/models/purchase.py
+++ b/mcfix_purchase/models/purchase.py
@@ -137,7 +137,9 @@ class PurchaseOrder(models.Model):
 class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
 
-    company_id = fields.Many2one('res.company', related=[], compute='_compute_line_company', string='Company', store=True, readonly=True)
+    company_id = fields.Many2one(
+        'res.company', related=[], compute='_compute_line_company',
+        string='Company', store=True, readonly=True)
 
     @api.depends('order_id', 'order_id.company_id')
     def _compute_line_company(self):

--- a/mcfix_purchase/views/purchase_order_view.xml
+++ b/mcfix_purchase/views/purchase_order_view.xml
@@ -15,10 +15,34 @@
             <field name="payment_term_id" position="attributes">
                 <attribute name="domain">[('company_id', '=', company_id)]</attribute>
             </field>
-            <field name="taxes_id" position="attributes">
-                <attribute name="domain">[('company_id', '=', company_id),('type_tax_use','=','purchase')]</attribute>
+
+            <field name='order_line' position="attributes">
+                <attribute name="context">{"default_company_id": company_id}</attribute>
             </field>
-            <field name="product_id" position="attributes">
+            <xpath expr='//field[@name="order_line"]/tree//field[@name="taxes_id"]' position='attributes'>
+                <attribute name="domain">[('company_id', '=', company_id),('type_tax_use','=','purchase')]</attribute>
+            </xpath>
+            <xpath expr='//field[@name="order_line"]/form//field[@name="taxes_id"]' position='attributes'>
+                <attribute name="domain">[('company_id', '=', company_id),('type_tax_use','=','purchase')]</attribute>
+            </xpath>
+            <xpath expr='//field[@name="order_line"]/tree//field[@name="product_id"]' position='attributes'>
+                <attribute name="domain">['|', ('company_id', '=', company_id),('company_id', '=', False)]</attribute>
+            </xpath>
+            <xpath expr='//field[@name="order_line"]/form//field[@name="product_id"]' position='attributes'>
+                <attribute name="domain">['|', ('company_id', '=', company_id),('company_id', '=', False)]</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="purchase_order_line_form2" model="ir.ui.view">
+        <field name="name">purchase.order.line.form2</field>
+        <field name="model">purchase.order.line</field>
+        <field name="inherit_id" ref="purchase.purchase_order_line_form2"/>
+        <field name="arch" type="xml">
+            <field name='taxes_id' position='attributes'>
+                <attribute name='domain'>[('type_tax_use','=','purchase'), ('company_id', '=', company_id)]</attribute>
+            </field>
+            <field name='product_id' position='attributes'>
                 <attribute name="domain">['|', ('company_id', '=', company_id),('company_id', '=', False)]</attribute>
             </field>
         </field>


### PR DESCRIPTION
Make order line company id computed and dependent so it defaults
better for a new purchase order line.

Also, ensure domains added to more views for alternate viewing
and editing.