### PR TITLE
[FIX] invoice creation and product views

### DIFF
--- a/mcfix_account/models/account_invoice.py
+++ b/mcfix_account/models/account_invoice.py
@@ -230,6 +230,18 @@ class AccountInvoice(models.Model):
 class AccountInvoiceLine(models.Model):
     _inherit = 'account.invoice.line'
 
+    @api.onchange('product_id')
+    def onchange_product_id(self):
+        return self.with_context(
+            force_company=self.invoice_id.company_id.id
+        )._onchange_product_id()
+
+    @api.onchange('account_id')
+    def onchange_account_id(self):
+        return self.with_context(
+            force_company=self.invoice_id.company_id.id
+        )._onchange_account_id()
+
     @api.model
     def change_company_id(self):
         part = self.invoice_id.partner_id

--- a/mcfix_account/views/account_invoice_view.xml
+++ b/mcfix_account/views/account_invoice_view.xml
@@ -74,4 +74,14 @@
             </xpath>
         </field>
     </record>
+    <record id="view_invoice_line_form" model="ir.ui.view">
+        <field name="name">account.invoice.line.form</field>
+        <field name="model">account.invoice.line</field>
+        <field name="inherit_id" ref="account.view_invoice_line_form" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="invoice_id" invisible="1"/>
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/mcfix_account/views/product_view.xml
+++ b/mcfix_account/views/product_view.xml
@@ -5,14 +5,8 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="account.product_template_form_view"/>
         <field name="arch" type="xml">
-            <field name="taxes_id" position="attributes">
-                <attribute name="domain">[('company_id', '=', company_id)]</attribute>
-            </field>
             <field name="property_account_income_id" position="attributes">
                 <attribute name="domain">[('internal_type','=','other'),('deprecated','=',False),('company_id', '=', company_id)]</attribute>
-            </field>
-            <field name="supplier_taxes_id" position="attributes">
-                <attribute name="domain">[('company_id', '=', company_id)]</attribute>
             </field>
             <field name="property_account_expense_id" position="attributes">
                 <attribute name="domain">[('internal_type','=','other'),('deprecated','=',False),('company_id', '=', company_id)]</attribute>

--- a/multicompany_property_purchase/views/product.xml
+++ b/multicompany_property_purchase/views/product.xml
@@ -21,9 +21,6 @@
             <field name="property_account_expense_id" position="attributes">
                 <attribute name="readonly">1</attribute>
             </field>
-            <field name='supplier_taxes_id' position="attributes">
-                <attribute name="readonly">1</attribute>
-            </field>
         </field>
     </record>
 


### PR DESCRIPTION
Two cases modified:
- Views of product disabled the option to change supplier_tax_ids
- On the creation of invoices, it was not working correctly if the company of the invoice was different than the company of the user.