### PR TITLE
remove company-specific domain in product taxes, as the product may not be assigned to a specific company

### DIFF
--- a/mcfix_account/models/product.py
+++ b/mcfix_account/models/product.py
@@ -5,13 +5,6 @@ from odoo.exceptions import ValidationError
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
-    taxes_id = fields.Many2many(
-        domain="[('type_tax_use', '=', 'sale'),"
-               "('company_id', '=', company_id)]")
-    supplier_taxes_id = fields.Many2many(
-        domain="[('type_tax_use', '=', 'purchase'),"
-               "('company_id', '=', company_id)]")
-
     @api.onchange('company_id')
     def _onchange_company_id(self):
         super(ProductTemplate, self)._onchange_company_id()


### PR DESCRIPTION
cc @etobella @mreficent 