### PR TITLE
[11.0][mcfix_base] allow partners to have banks from various companies

### DIFF
--- a/mcfix_base/models/res_partner.py
+++ b/mcfix_base/models/res_partner.py
@@ -88,7 +88,10 @@ class Partner(models.Model):
 
     def _check_company_id_fields(self):
         res = super()._check_company_id_fields()
-        res += [self.child_ids, self.bank_ids, ]
+        # We choose not to include bank_ids because a partner might have
+        # banks in various companies (for historical reasons),
+        # regardless of what company is now assigned to.
+        res += [self.child_ids]
         return res
 
     def _check_company_id_search(self):


### PR DESCRIPTION
When you have a partner in company 2 that has a bank in company 2, and then want to switch this partner to company 1, the bank of company 2 should be respected. Because assigning a company to partners and products is meant to be used for visibility.