### PR TITLE
remove company suffix in sale order line description

### DIFF
--- a/mcfix_sale/models/sale.py
+++ b/mcfix_sale/models/sale.py
@@ -159,7 +159,9 @@ class SaleOrderLine(models.Model):
     @api.onchange('product_id')
     def product_id_change(self):
         self.company_id = self.order_id.company_id
-        result = super().product_id_change()
+        result = super(
+            SaleOrderLine,
+            self.with_context(not_display_company=True)).product_id_change()
         for line in self:
             line.tax_id = line.tax_id.filtered(
                 lambda r: r.company_id == line.order_id.company_id)


### PR DESCRIPTION
Fix this:
![image](https://user-images.githubusercontent.com/7683926/40368530-53645ede-5ddc-11e8-81cf-cbc3c3066193.png)


So it becomes:
![image](https://user-images.githubusercontent.com/7683926/40368502-40ee2d34-5ddc-11e8-95d9-712e7e09c1a4.png)
