### PR TITLE
[mcfix_base] The partner associated to the user should NOT have any company assigned

### DIFF
--- a/mcfix_base/models/__init__.py
+++ b/mcfix_base/models/__init__.py
@@ -5,3 +5,4 @@ from . import res_company
 from . import res_config_settings
 from . import res_partner
 from . import res_partner_bank
+from . import res_users

--- a/mcfix_base/models/res_users.py
+++ b/mcfix_base/models/res_users.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Creu Blanca
+# Copyright 2019 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from odoo import api, models
+
+
+class Users(models.Model):
+    _inherit = "res.users"
+
+    @api.model
+    def create(self, vals):
+        # We reset the company of the partner to blank
+        user = super(Users, self).create(vals)
+        if user.partner_id.company_id:
+            user.partner_id.write({'company_id': False})
+        return user
+
+    @api.multi
+    def write(self, values):
+        # We reset the company of the partner to blank
+        res = super(Users, self).write(values)
+        if 'company_id' in values:
+            for user in self:
+                # if partner is global we keep it that way
+                if user.partner_id.company_id:
+                    user.partner_id.write({'company_id': False})
+        return res

--- a/mcfix_base/tests/test_res_partner.py
+++ b/mcfix_base/tests/test_res_partner.py
@@ -18,8 +18,8 @@ class TestResPartner(TransactionCase):
 
     def setUp(self):
         super(TestResPartner, self).setUp()
-        employees_group = self.env.ref('base.group_user')
-        partner_manager_group = self.env.ref('base.group_partner_manager')
+        self.employees_group = self.env.ref('base.group_user')
+        self.partner_manager_group = self.env.ref('base.group_partner_manager')
         self.company = self.env['res.company'].create({
             'name': 'Test company'
         })
@@ -37,8 +37,8 @@ class TestResPartner(TransactionCase):
             {'name': 'Test User',
              'login': 'test_user',
              'email': 'test@oca.com',
-             'groups_id': [(6, 0, [employees_group.id,
-                                   partner_manager_group.id])],
+             'groups_id': [(6, 0, [self.employees_group.id,
+                                   self.partner_manager_group.id])],
              'company_id': self.company.id,
              'company_ids': [(4, self.company.id)],
              })
@@ -70,3 +70,18 @@ class TestResPartner(TransactionCase):
         partner_3.parent_id = partner_2
         partner_2.parent_id = False
         self.assertEqual(partner_3.commercial_partner_id, partner_2)
+
+    def test_user_partner_company(self):
+        user = self.env['res.users'].sudo(self.env.user).with_context(
+            no_reset_password=True).create(
+            {'name': 'Test User',
+             'login': 'test_user_2',
+             'email': 'test@oca.com',
+             'groups_id': [(6, 0, [self.employees_group.id,
+                                   self.partner_manager_group.id])],
+             'company_id': self.company.id,
+             'company_ids': [(4, self.company.id), (4, self.company_2.id)],
+             })
+        self.assertFalse(user.partner_id.company_id)
+        user.company_id = self.company_2
+        self.assertFalse(user.partner_id.company_id)


### PR DESCRIPTION
That way the partner can be selected as salesperson in invoices, for example.

cc @etobella @jarroyomorales