### PR TITLE
[11.0][IMP] mcfix_account: Display only company related from Account Bank Statements to reconcile models

### DIFF
--- a/mcfix_account/models/account_bank_statement.py
+++ b/mcfix_account/models/account_bank_statement.py
@@ -7,6 +7,10 @@ class AccountBankStatement(models.Model):
     _inherit = "account.bank.statement"
 
     @api.multi
+    def get_company_ids(self):
+        return self.mapped('company_id').ids
+
+    @api.multi
     def reconciliation_widget_preprocess(self):
         # This is the same code as the original method except for the fact
         # that here will fetch bank statement data for the child companies

--- a/mcfix_account/static/src/js/reconciliation/reconciliation_model.js
+++ b/mcfix_account/static/src/js/reconciliation/reconciliation_model.js
@@ -23,5 +23,20 @@ odoo.define('account.ReconciliationModel.multicompany', function (require) {
                     }
                 });
         },
+        load: function (context) {
+            var self = this;
+            var _super = self._super.bind(self)
+            var statement_ids = context.statement_ids;
+            return self._rpc({
+                    model: 'account.bank.statement',
+                    method: 'get_company_ids',
+                    args: [statement_ids,],
+                }).then(function (result) {
+                    if (result.length > 0) {
+                        context.company_ids = result;
+                    }
+                    return _super(context);
+                });
+        }
     });
 });


### PR DESCRIPTION
Add companies from Account Bank Statement to context to display company related reconciliation models.

CC ~ @Eficent  @ageficent @jbeficent @etobella @mreficent 

