### PR TITLE
[13.0][IMP] multicompany_property_*: allow records without company

### DIFF
--- a/multicompany_property_account/views/partner_views.xml
+++ b/multicompany_property_account/views/partner_views.xml
@@ -37,11 +37,11 @@
         />
         <field
           name="property_payment_term_id"
-          domain="['|', ('company_id', '=', False), ('company_id','=',company_id)]"
+          domain="['|', ('company_id','=',company_id), ('company_id','=',False)]"
         />
         <field
           name="property_supplier_payment_term_id"
-          domain="['|', ('company_id', '=', False), ('company_id','=',company_id)]"
+          domain="['|', ('company_id','=',company_id), ('company_id','=',False)]"
         />
       </field>
     </field>
@@ -59,11 +59,11 @@
           <group>
             <field
               name="property_account_payable_id"
-              domain="[('internal_type', '=', 'payable'), ('deprecated', '=', False),('company_id','=',company_id)]"
+              domain="[('internal_type', '=', 'payable'), ('deprecated', '=', False), ('company_id','=',company_id)]"
             />
             <field
               name="property_account_receivable_id"
-              domain="[('internal_type', '=', 'receivable'), ('deprecated', '=', False),('company_id','=',company_id)]"
+              domain="[('internal_type', '=', 'receivable'), ('deprecated', '=', False), ('company_id','=',company_id)]"
             />
             <field
               name="property_account_position_id"
@@ -71,11 +71,11 @@
             />
             <field
               name="property_payment_term_id"
-              domain="['|', ('company_id', '=', False), ('company_id','=',company_id)]"
+              domain="['|', ('company_id','=',company_id), ('company_id','=',False)]"
             />
             <field
               name="property_supplier_payment_term_id"
-              domain="['|', ('company_id', '=', False), ('company_id','=',company_id)]"
+              domain="['|', ('company_id','=',company_id), ('company_id','=',False)]"
             />
             <field name="trust" domain="[('company_id','=',company_id)]" />
           </group>

--- a/multicompany_property_account/views/product_category_views.xml
+++ b/multicompany_property_account/views/product_category_views.xml
@@ -26,11 +26,11 @@
           <group string="Account Properties">
             <field
               name="property_account_income_categ_id"
-              domain="[('internal_type','=','other'),('deprecated', '=', False),('company_id','=',company_id)]"
+              domain="[('internal_type','=','other'),('deprecated', '=', False), ('company_id','=',company_id)]"
             />
             <field
               name="property_account_expense_categ_id"
-              domain="[('internal_type','=','other'),('deprecated', '=', False),('company_id','=',company_id)]"
+              domain="[('internal_type','=','other'),('deprecated', '=', False), ('company_id','=',company_id)]"
             />
           </group>
         </group>

--- a/multicompany_property_account/views/product_views.xml
+++ b/multicompany_property_account/views/product_views.xml
@@ -26,11 +26,11 @@
           <group name="accounting_group">
             <field
               name="property_account_income_id"
-              domain="[('deprecated', '=', False),('company_id','=',company_id)]"
+              domain="[('deprecated', '=', False), ('company_id','=',company_id)]"
             />
             <field
               name="property_account_expense_id"
-              domain="[('deprecated', '=', False),('company_id','=',company_id)]"
+              domain="[('deprecated', '=', False), ('company_id','=',company_id)]"
             />
           </group>
         </page>

--- a/multicompany_property_account/views/res_company_views.xml
+++ b/multicompany_property_account/views/res_company_views.xml
@@ -21,7 +21,7 @@
               <field name="default_purchase_tax_id" />
               <field
                 name="transfer_account_id"
-                domain="[('company_id', '=', active_id)]"
+                domain="[('company_id','=',active_id)]"
                 context="{'default_company_id': active_id}"
               />
               <field

--- a/multicompany_property_account_payment_partner/views/partner_views.xml
+++ b/multicompany_property_account_payment_partner/views/partner_views.xml
@@ -24,13 +24,13 @@
       <field name="property_supplier_payment_term_id" position="after">
         <field
           name="supplier_payment_mode_id"
-          domain="[('payment_type', '=', 'outbound'),('company_id','=',company_id)]"
+          domain="[('payment_type', '=', 'outbound'),'|', ('company_id','=',company_id), ('company_id','=',False)]"
         />
       </field>
       <field name="property_payment_term_id" position="after">
         <field
           name="customer_payment_mode_id"
-          domain="[('payment_type', '=', 'inbound'),('company_id','=',company_id)]"
+          domain="[('payment_type', '=', 'inbound'),'|', ('company_id','=',company_id), ('company_id','=',False)]"
         />
       </field>
     </field>
@@ -47,11 +47,11 @@
         <group>
           <field
             name="supplier_payment_mode_id"
-            domain="[('payment_type', '=', 'outbound'),('company_id','=',company_id)]"
+            domain="[('payment_type', '=', 'outbound'),'|', ('company_id','=',company_id), ('company_id','=',False)]"
           />
           <field
             name="customer_payment_mode_id"
-            domain="[('payment_type', '=', 'inbound'),('company_id','=',company_id)]"
+            domain="[('payment_type', '=', 'inbound'),'|', ('company_id','=',company_id), ('company_id','=',False)]"
           />
         </group>
       </page>

--- a/multicompany_property_stock_account/views/product_category_views.xml
+++ b/multicompany_property_stock_account/views/product_category_views.xml
@@ -37,15 +37,15 @@
         <group name="account_stock_property" string="Account Stock Properties">
           <field
             name="property_stock_account_input_categ_id"
-            domain="[('deprecated', '=', False),('company_id','=',company_id)]"
+            domain="[('deprecated', '=', False), ('company_id','=',company_id)]"
           />
           <field
             name="property_stock_account_output_categ_id"
-            domain="[('deprecated', '=', False),('company_id','=',company_id)]"
+            domain="[('deprecated', '=', False), ('company_id','=',company_id)]"
           />
           <field
             name="property_stock_valuation_account_id"
-            domain="[('deprecated', '=', False),('company_id','=',company_id)]"
+            domain="[('deprecated', '=', False), ('company_id','=',company_id)]"
           />
           <field
             name="property_stock_journal"


### PR DESCRIPTION
Currently, the domain filters out all records for which the company is not the same as the company being edited but IMO records without company should be available for all companies.