### PR TITLE
[13.0][FIX] multicompany_property_base: add description to res.partner.property model

### DIFF
--- a/multicompany_property_base/models/res_partner.py
+++ b/multicompany_property_base/models/res_partner.py
@@ -36,6 +36,7 @@ class Partner(models.Model):
 class PartnerProperty(models.TransientModel):
     _name = "res.partner.property"
     _inherit = "model.property"
+    _description = "Partner Properties"
 
     partner_id = fields.Many2one(comodel_name="res.partner", string="Partner")
 


### PR DESCRIPTION
Prevent this to happen:

`odoo_1                        | 2021-05-19 10:31:11,451 1 WARNING devel odoo.models: The model res.partner.property has no _description` 

@MiquelRForgeFlow  Does this make sense? The inherited model has already a description but for some reason it is asking for another.