### PR TITLE
[FIX]multicompany_property_base: fix company configuration properties display in partner form

### DIFF
--- a/multicompany_property_base/views/partner_views.xml
+++ b/multicompany_property_base/views/partner_views.xml
@@ -7,9 +7,7 @@
     <field name="arch" type="xml">
       <page name="internal_notes" position="after">
         <page string="Company Configuration">
-          <group>
-            <field name="property_ids" nolabel="1" />
-          </group>
+          <field name="property_ids" nolabel="1" />
         </page>
       </page>
     </field>


### PR DESCRIPTION
Minor fix to prevent wrong display. 
Before the fix:

![image](https://user-images.githubusercontent.com/71635103/120601807-acc2be80-c44a-11eb-8cb1-32952cdfcf84.png)

After the fix:

![image](https://user-images.githubusercontent.com/71635103/120601702-93ba0d80-c44a-11eb-9439-ba6d2587ffd2.png)
