### PR TITLE
[13.0][FIX]multicompany_property_account: make account payable/receivable not required in partner view

### DIFF
--- a/multicompany_property_account/views/partner_views.xml
+++ b/multicompany_property_account/views/partner_views.xml
@@ -13,9 +13,11 @@
       </field>
       <field name="property_account_receivable_id" position="attributes">
         <attribute name="readonly">True</attribute>
+        <attribute name="required">0</attribute>
       </field>
       <field name="property_account_payable_id" position="attributes">
         <attribute name="readonly">True</attribute>
+        <attribute name="required">0</attribute>
       </field>
       <field name="property_account_position_id" position="attributes">
         <attribute name="readonly">True</attribute>


### PR DESCRIPTION
In order to define the property fields in the property wizard, you need to be in edit mode in the partner form view.

The wizard will only create the properties when the partner form view is saved, but in the case where these required fields are empty you will not be able to save the partner form.

Therefore, in the scenario where you don't have a receivable/payable account defined for the partner, you can't add one through the wizard.

To fix this we can drop the required attribute in the view, as the fields are readonly and they are already required in the wizard.