### PR TITLE
[14.0][FIX] multicompany_property_account: remove current_company_id from domain

### DIFF
--- a/multicompany_property_account/models/product.py
+++ b/multicompany_property_account/models/product.py
@@ -11,8 +11,7 @@ class ProductProperty(models.TransientModel):
     property_account_income_id = fields.Many2one(
         comodel_name="account.account",
         string="Income Account",
-        domain="['&', ('deprecated', '=', False),"
-        "('company_id', '=', current_company_id)]",
+        domain=[("deprecated", "=", False)],
         compute="_compute_property_fields",
         readonly=False,
         store=False,
@@ -22,8 +21,7 @@ class ProductProperty(models.TransientModel):
     property_account_expense_id = fields.Many2one(
         comodel_name="account.account",
         string="Expense Account",
-        domain="['&', ('deprecated', '=', False),"
-        "('company_id', '=', current_company_id)]",
+        domain=[("deprecated", "=", False)],
         compute="_compute_property_fields",
         readonly=False,
         store=False,

--- a/multicompany_property_account/models/product_category.py
+++ b/multicompany_property_account/models/product_category.py
@@ -11,8 +11,7 @@ class ProductCategoryProperty(models.TransientModel):
     property_account_income_categ_id = fields.Many2one(
         comodel_name="account.account",
         string="Income Account",
-        domain="['&', ('deprecated', '=', False),"
-        "('company_id', '=', current_company_id)]",
+        domain=[("deprecated", "=", False)],
         compute="_compute_property_fields",
         readonly=False,
         store=False,
@@ -21,8 +20,7 @@ class ProductCategoryProperty(models.TransientModel):
     property_account_expense_categ_id = fields.Many2one(
         comodel_name="account.account",
         string="Expense Account",
-        domain="['&', ('deprecated', '=', False),"
-        "('company_id', '=', current_company_id)]",
+        domain=[("deprecated", "=", False)],
         compute="_compute_property_fields",
         readonly=False,
         store=False,


### PR DESCRIPTION
Forwardport of https://github.com/ForgeFlow/multicompany-fixes/pull/133