### PR TITLE
[13.0][FIX] multicompany_property_stock_account

### DIFF
--- a/multicompany_property_stock_account/models/product_category.py
+++ b/multicompany_property_stock_account/models/product_category.py
@@ -16,6 +16,7 @@ class ProductCategoryProperty(models.TransientModel):
         string="Inventory Valuation",
         compute="_compute_property_fields",
         readonly=False,
+        required=True,
         help="If perpetual valuation is enabled for a product, the system "
         "will automatically create journal entries corresponding to "
         "stock moves, with product price as specified by the 'Costing "
@@ -34,6 +35,7 @@ class ProductCategoryProperty(models.TransientModel):
         string="Costing Method",
         compute="_compute_property_fields",
         readonly=False,
+        required=True,
         help="Standard Price: The products are valued at their standard cost "
         "defined on the product.\nAverage Cost (AVCO): The products are valued "
         "at weighted average cost.\nFirst In First Out (FIFO): The products "


### PR DESCRIPTION
fields property_valuation and property_cost_method have to be required

Because those are required in the product category they should be required for all companies.
Otherwise, if you leave any of those fields empty for a company and you save then
you will not be able to edit anything else in the product category, you will get
all the time an error saying "Missing required fields". And you will not be able to going back
because there is no way to change those fields in the category itself.

Don't believe me just test it