### PR TITLE
[FIX] multicompany_property_stock_account: property_stock_journal and

### DIFF
--- a/multicompany_property_stock_account/models/product_category.py
+++ b/multicompany_property_stock_account/models/product_category.py
@@ -47,6 +47,7 @@ class ProductCategoryProperty(models.TransientModel):
         "Stock Journal",
         compute="_compute_property_fields",
         readonly=False,
+        required=True,
         help="When doing real-time inventory valuation, this is "
         "the Accounting Journal in which entries will be "
         "automatically posted when stock moves are processed.",
@@ -57,6 +58,7 @@ class ProductCategoryProperty(models.TransientModel):
         domain=[("deprecated", "=", False)],
         compute="_compute_property_fields",
         readonly=False,
+        required=True,
         help="When doing real-time inventory valuation, counterpart "
         "journal items for all incoming stock moves will be posted "
         "in this account, unless "
@@ -71,6 +73,7 @@ class ProductCategoryProperty(models.TransientModel):
         domain=[("deprecated", "=", False)],
         compute="_compute_property_fields",
         readonly=False,
+        required=True,
         help="When doing real-time inventory valuation, counterpart journal "
         "items for all outgoing stock moves will be posted in this "
         "account, unless there is a specific valuation account set "
@@ -83,6 +86,7 @@ class ProductCategoryProperty(models.TransientModel):
         "Stock Valuation Account",
         compute="_compute_property_fields",
         readonly=False,
+        required=True,
         domain=[("deprecated", "=", False)],
         help="When real-time inventory valuation is enabled "
         "on a product, this account will hold the current "


### PR DESCRIPTION
property_stock_account_/input/output_categ_id and property_stock_valuation_account_id
are required in the product category so it should be required for all companies.
Otherwise, if you leave any of those fields empty for a company and you save then
you will not be able to edit anything else in the product category, you will get
all the time an error saying "Missing required fields". And you will not be able to going back
because there is no way to change those fields in the category itself.

![2022-03-25_09-07](https://user-images.githubusercontent.com/19620251/160083965-940ecd45-8e1e-438b-8d1c-f447c146dc20.png)

