### PR TITLE
[ENH] mcfix_account: relax analytic account restriction: Second part

### DIFF
--- a/mcfix_account/views/account_invoice_view.xml
+++ b/mcfix_account/views/account_invoice_view.xml
@@ -31,6 +31,9 @@
             <xpath expr="/form/sheet/notebook/page/field/tree/field[@name='product_id']" position="attributes">
                 <attribute name="domain">[('purchase_ok','=',True), '|', ('company_id', '=', parent.company_id), ('company_id', '=', False)]</attribute>
             </xpath>
+            <xpath expr="/form/sheet/notebook/page/field/tree/field[@name='account_analytic_id']" position="attributes">
+                <attribute name="domain">['|', ('company_id', '=', parent.company_id), ('company_id', '=', False)]</attribute>
+            </xpath>
             <xpath expr="/form/sheet/notebook/page/group/group/div/field/tree/field[@name='account_id']" position="attributes">
                 <attribute name="domain">[('company_id', '=', parent.company_id)]</attribute>
             </xpath>
@@ -66,6 +69,9 @@
             </field>
             <xpath expr="/form/sheet/notebook/page/field[@name='invoice_line_ids']/tree/field[@name='product_id']" position="attributes">
                 <attribute name="domain">[('sale_ok','=',True), '|', ('company_id', '=', parent.company_id), ('company_id', '=', False)]</attribute>
+            </xpath>
+            <xpath expr="/form/sheet/notebook/page/field[@name='invoice_line_ids']/tree/field[@name='account_analytic_id']" position="attributes">
+                <attribute name="domain">['|', ('company_id', '=', parent.company_id), ('company_id', '=', False)]</attribute>
             </xpath>
             <xpath expr="/form/sheet/notebook/page/field[@name='invoice_line_ids']/kanban" position="inside">
                 <field name="company_id" invisible="1"/>


### PR DESCRIPTION
Seems that Odoo restricts the analytic company in view only, so to be coherent, let's use the model approach.
Allow to add analytic accounts with no company for invoices