### PR TITLE
[13.0][FIX] multicompany_property_account: fix product category account domain

### DIFF
--- a/multicompany_property_account/models/res_company.py
+++ b/multicompany_property_account/models/res_company.py
@@ -69,7 +69,7 @@ class ResCompany(models.Model):
     )
     categ_account_expense_id = fields.Many2one(
         "account.account",
-        domain="[('internal_type', '=', 'expense'),"
+        domain="[('internal_type', '=', 'other'),"
         "('deprecated', '=', False),"
         "('company_id', '=', active_id)]",
         compute="_compute_categ_account_expense",
@@ -78,7 +78,7 @@ class ResCompany(models.Model):
     )
     categ_account_income_id = fields.Many2one(
         "account.account",
-        domain="[('internal_type', '=', 'income'),"
+        domain="[('internal_type', '=', 'other'),"
         "('deprecated', '=', False),"
         "('company_id', '=', active_id)]",
         compute="_compute_categ_account_income",


### PR DESCRIPTION
Align with the domain in the view: https://github.com/ForgeFlow/multicompany-fixes/blob/02bf0e31af487ca3e7862acb00aad921ae298a8b/multicompany_property_account/views/product_category_views.xml#L29