### PR TITLE
[13.0][IMP] mcfix_stock: add company_id when create stock_move without warehouse

### DIFF
--- a/mcfix_stock/models/stock_move.py
+++ b/mcfix_stock/models/stock_move.py
@@ -19,7 +19,10 @@ class StockMove(models.Model):
         # If we did not get the company, try to derive from the picking
         if vals.get("picking_id") and not vals.get("company_id"):
             picking = self.env["stock.picking"].browse(vals["picking_id"])
-            vals["company_id"] = picking.picking_type_id.warehouse_id.company_id.id
+            vals["company_id"] = (
+                picking.picking_type_id.warehouse_id.company_id.id
+                or picking.company_id.id
+            )
 
         # If we did not get the company or picking, try to derive
         # from either the source or destination location.


### PR DESCRIPTION
Forward port of https://github.com/ForgeFlow/multicompany-fixes/pull/177.